### PR TITLE
Fix jquery assets failure on generated app / Bump version to 1.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,3 +27,7 @@
 * Add `brakeman`
 * Add `letter_opener`
 * Add `rubocop`
+
+1.0.1 (02 Maio 2016)
+
+* Fix bug: remove missing jquery from generated application.js

--- a/lib/code42template/app_builder.rb
+++ b/lib/code42template/app_builder.rb
@@ -112,6 +112,10 @@ module Code42Template
       end
     end
 
+    def remove_jquery
+      gsub_file 'app/assets/javascripts/application.js', /^.+jquery.*\n/, ''
+    end
+
     def remove_routes_comment_lines
       replace_in_file 'config/routes.rb',
         /Rails\.application\.routes\.draw do.*end/m,

--- a/lib/code42template/generators/app_generator.rb
+++ b/lib/code42template/generators/app_generator.rb
@@ -23,6 +23,7 @@ module Code42Template
     def code42_customization
       invoke :customize_gemfile
       invoke :setup_development_environment
+      invoke :setup_assets
       invoke :setup_test_environment
       invoke :setup_production_environment
       invoke :setup_staging_environment
@@ -60,6 +61,12 @@ module Code42Template
       build :add_bullet_gem_configuration
       build :configure_quiet_assets
       build :configure_letter_opener
+    end
+
+    def setup_assets
+      say 'Setting up assets'
+
+      build :remove_jquery
     end
 
     def setup_test_environment

--- a/lib/code42template/version.rb
+++ b/lib/code42template/version.rb
@@ -1,5 +1,5 @@
 module Code42Template
   RAILS_VERSION = "~> 4.2.5"
   RUBY_VERSION = IO.read("#{File.dirname(__FILE__)}/../../.ruby-version").strip
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe "Create a new project with default configuration" do
     end
   end
 
+  it 'removes jquery require statements from application.js' do
+    application_js = read_file('app/assets/javascripts/application.js')
+
+    expect(application_js).to_not match(/jquery/)
+  end
+
   it "adds explicit quiet_assets configuration" do
     result = IO.read("#{project_path}/config/application.rb")
 
@@ -100,5 +106,13 @@ RSpec.describe "Create a new project with default configuration" do
 
   def app_name
     Code42TemplateTestHelpers::APP_NAME
+  end
+
+  def read_file(path)
+    IO.read(file_path(path))
+  end
+
+  def file_path(path)
+    File.join(project_path, path)
   end
 end


### PR DESCRIPTION
The app was failing out of the box when rendering the `application.html.erb` layout, because it could not find jquery references of `application.js`.